### PR TITLE
Resolve bundle name issue in windows

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gpjenkins/GlobalizationPipelineBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/gpjenkins/GlobalizationPipelineBuilder.java
@@ -309,11 +309,11 @@ public class GlobalizationPipelineBuilder extends Builder implements SimpleBuild
 		String pkgName = "";
 		if(DefaultResourceFilterProvider.isJavaType(type)){
 			pkgName = parent == null ? "" :
-				computeParentFromBaseDir(path).replace(File.separatorChar, '.');
+				computeParentFromBaseDir(path).replace('/', '.');
 		}
 		else{
 			pkgName = parent == null ? "" :
-				computeParentFromBaseDir(path).replace(File.separatorChar, '-');
+				computeParentFromBaseDir(path).replace('/', '-');
 		}
 		String fileName = path.getName().replaceAll(" ", "_");
 		if (DefaultResourceFilterProvider.isJavaType(type)) {


### PR DESCRIPTION
computeParentFromBaseDir invokes toURI(), which has tranfered '\\' to '/'